### PR TITLE
Undo a mistaken chunk registration change - Closes #1302

### DIFF
--- a/Spigot-Server-Patches/0157-Chunk-registration-fixes.patch
+++ b/Spigot-Server-Patches/0157-Chunk-registration-fixes.patch
@@ -1,4 +1,4 @@
-From 8133b92590c9b861b7342bcc1079c23f2e106450 Mon Sep 17 00:00:00 2001
+From 5207f32bb4fc93b43be6ff957e7846173540a824 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 21 Sep 2016 22:54:28 -0400
 Subject: [PATCH] Chunk registration fixes
@@ -8,7 +8,7 @@ World checks and the Chunk Add logic are inconsistent on how Y > 256, < 0, is tr
 Keep them consistent
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 6e37c4366..ea24a6e4c 100644
+index 6e37c4366f..000d2eeb93 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -1770,7 +1770,7 @@ public abstract class World implements IBlockAccess {
@@ -20,15 +20,6 @@ index 6e37c4366..ea24a6e4c 100644
          int k = MathHelper.floor(entity.locZ / 16.0D);
  
          if (!entity.aa || entity.ab != i || entity.ac != j || entity.ad != k) {
-@@ -1778,7 +1778,7 @@ public abstract class World implements IBlockAccess {
-                 this.getChunkAt(entity.ab, entity.ad).a(entity, entity.ac);
-             }
- 
--            if (!entity.bD() && !this.isChunkLoaded(i, k, true)) {
-+            if (false && !entity.bD() && !this.isChunkLoaded(i, k, true)) { // Paper - Always send entities into a new chunk, never lose them
-                 entity.aa = false;
-             } else {
-                 this.getChunkAt(i, k).a(entity);
 -- 
 2.18.0
 


### PR DESCRIPTION
I misinterpreted some code as a risk of entity loss, but now
after deeper study, I see how that code was used more and why
it was adding entities to chunks that they shouldn't have been
in during a world transfer process.